### PR TITLE
Set incoming sockets into nonblocking mode

### DIFF
--- a/timely-adapter/src/connect.rs
+++ b/timely-adapter/src/connect.rs
@@ -72,7 +72,11 @@ pub fn open_sockets(count: usize) -> Arc<Mutex<Vec<Option<TcpStream>>>> {
     let listener = TcpListener::bind("127.0.0.1:8000").unwrap();
     Arc::new(Mutex::new(
         (0..count)
-            .map(|_| Some(listener.incoming().next().unwrap().unwrap()))
+            .map(|_| {
+                let mut socket = listener.incoming().next().unwrap().unwrap();
+                socket.set_nonblocking(true);
+                Some(socket)
+             })
             .collect::<Vec<_>>(),
     ))
 }


### PR DESCRIPTION
This may prevent the input readers from parking the worker threads when there's no incoming data.